### PR TITLE
Fix max tokens issue for gpt4o

### DIFF
--- a/bot/openai_helper.py
+++ b/bot/openai_helper.py
@@ -62,7 +62,7 @@ def default_max_tokens(model: str = None) -> int:
     elif model in GPT_4_128K_MODELS:
         return 4096
     elif model in GPT_4O_MODELS:
-        return 128000
+        return 16384
     elif model in O1_MODELS:
         return 32768
     elif model in ANTHROPIC:


### PR DESCRIPTION
Hi, i m tying to test your fork with `gpt-4o` model and encountered with following error response:

```
Error: ⚠️ _OpenAI Invalid request._ ⚠️
Error code: 400 - {'error': {'message': 'max_tokens is too large: 102400. This model supports at most 16384 completion tokens, whereas you provided 102400.', 'type': 'invalid_request_error', 'param': 'max_tokens', 'code': None}}
```

I m not sure that this is right way but you have no Issues enabled so no way to discuss a case before PR.